### PR TITLE
add: dowdload badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
     <a href="https://pypi.org/project/ghs">
       <img src="https://img.shields.io/pypi/pyversions/ghs.svg" />
     </a>
-	  
+    <a href="https://pypi.org/project/ghs">
+      <img src="https://img.shields.io/pypi/dm/ghs" />
+    </a>
   </p>
 </p>
 


### PR DESCRIPTION
I have added download per month badge. But there is no "total download" badge available. See https://github.com/badges/shields/issues/4319 

Issue #2
